### PR TITLE
Synchronisation over distributed places

### DIFF
--- a/distributed-places-lib/racket/place/distributed.rkt
+++ b/distributed-places-lib/racket/place/distributed.rkt
@@ -157,7 +157,7 @@
 (define (write-flush msg [p (current-output-port)])
 ;  (write msg (current-output-port))
 ;  (newline)
-  (flush-output)
+;  (flush-output)
   (write msg p)
   (flush-output p))
 


### PR DESCRIPTION
See mailing list discussion date [2015-03-20] subject: "[racket] distributed place messages: "write" isn't atomic"

* This pull request defaults to using the semaphores
* Not sure how to ensure that exception handling releases the semaphores